### PR TITLE
Wrap os.makedirs to prevent failings when tests are running in parallel

### DIFF
--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -57,7 +57,10 @@ def reset_directory(path, skip_clean_results="no"):
         os.makedirs(path)
     else:
         if not os.path.isdir(path):
-            os.makedirs(path)
+            try:
+                os.makedirs(path)
+            except OSError:
+                print('Result folder %s was created in another flow.' % path)
 
 
 def get_common_options():


### PR DESCRIPTION
Sometimes when we are running ~20 parallel flows sst-remote tests, I can see failings during creation results folder:
```
Start test ...
Traceback (most recent call last):
  File "...CENSORED../workspace/bin/sst-remote", line 9, in <module>
    load_entry_point('sst==0.2.5dev', 'console_scripts', 'sst-remote')()
  File "...CENSORED../workspace/envs/b38ef3013c7ec8d5c51607cc217e40de/local/lib/python2.7/site-packages/sst/scripts/remote.py", line 40, in main
    cmd_opts.skip_clean_results)
  File "...CENSORED../workspace/envs/b38ef3013c7ec8d5c51607cc217e40de/local/lib/python2.7/site-packages/sst/command.py", line 60, in reset_directory
    os.makedirs(path)
  File "...CENSORED../workspace/envs/b38ef3013c7ec8d5c51607cc217e40de/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '...CENSORED../workspace/results'
```
To avoid this, I wrap os.makedirs in try-except.