### PR TITLE
Downgrade Selenium to 2.44.0 for native support in Firefox

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 junitxml==0.7
 python-subunit==0.0.16
-selenium==2.45.0
+selenium==2.44.0
 testtools==0.9.34

--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.6dev'
+__version__ = '0.2.7dev'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 


### PR DESCRIPTION
Selenium 2.45.0 uses synthesised handling for Firefox. Downgrading to 2.44.0 for usage with Firefox 33 (native support).

See: https://selenium.googlecode.com/git/py/CHANGES