### PR TITLE
Handle invalid log levels parameters

### DIFF
--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -178,11 +178,15 @@ def get_opts(get_options, args=None):
 
     logging.basicConfig(format='    %(levelname)s:%(name)s:%(message)s')
     logger = logging.getLogger('SST')
+
+    numeric_level = getattr(logging, cmd_opts.log_level.upper(), logging.DEBUG)
     if cmd_opts.quiet:
         logger.setLevel(logging.WARNING)
+    elif isinstance(numeric_level, int):
+        logger.setLevel(numeric_level)
     else:
-        logger.setLevel(
-            getattr(logging, cmd_opts.log_level.upper(), logging.DEBUG))
+        logger.setLevel(logging.DEBUG)
+
     # FIXME: We shouldn't be modifying anything in the 'actions' module, this
     # violates isolation and will make it hard to test. -- vila 2013-04-10
     if cmd_opts.disable_flags:


### PR DESCRIPTION
We actually realized that there wasn't enough error handling when passing in the log level parameter. A user could pass in `BASIC_FORMAT` and get back a string that would throw an error when trying to run `logger.setLevel` with that string.  

While `BASIC_FORMAT` is the only string that would cause that error, future changes to the logger module could introduce other variables that would cause the same issue. 

This error handling is similar to what they recommend in the [python 2 logging documentation](https://docs.python.org/2/howto/logging.html#logging-to-a-file)

@arnlaugsson @kamyanskiy 