### PR TITLE
Move concurrency to common options from run

### DIFF
--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.7dev'
+__version__ = '0.2.8dev'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -119,6 +119,9 @@ def get_common_options():
     parser.add_option('--log', '--log-level', dest='log_level',
                       default='DEBUG',
                       help=('Set log level for SST logger'))
+    parser.add_option('-c', '--concurrency', dest='concurrency',
+                      default=1, type='int',
+                      help='concurrency (number of procs)')
     return parser
 
 
@@ -127,9 +130,6 @@ def get_run_options():
     parser.add_option('-x', dest='xserver_headless',
                       default=False, action='store_true',
                       help='run browser in headless xserver (Xvfb)')
-    parser.add_option('-c', '--concurrency', dest='concurrency',
-                      default=1, type='int',
-                      help='concurrency (number of procs)')
     return parser
 
 

--- a/src/sst/scripts/remote.py
+++ b/src/sst/scripts/remote.py
@@ -56,6 +56,7 @@ def main():
         browser_factory=browser_factory,
         shared_directory=cmd_opts.shared_directory,
         screenshots_on=cmd_opts.screenshots_on,
+        concurrency_num=cmd_opts.concurrency,
         failfast=cmd_opts.failfast,
         debug=cmd_opts.debug,
         extended=cmd_opts.extended_tracebacks,


### PR DESCRIPTION
Concurrency should be a passable arguement for remote runner as well as local runner.

In order to run multiple test using Selenium Grid, this option needs to be accessible to the remote runner as well as the local one.

Please review @kamyanskiy 